### PR TITLE
update mui/material to latest version 5.11.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@inovua/reactdatagrid-community": "^4.21.0",
     "@mui/icons-material": "^5.0.5",
     "@mui/lab": "^5.0.0-alpha.97",
-    "@mui/material": "^5.0.6",
+    "@mui/material": "^5.11.8",
     "@mui/system": "^5.0.6",
     "@mui/x-date-pickers": "^5.0.8",
     "classnames": "^2.3.1",


### PR DESCRIPTION
- fixes problems with type errors when using Popper

More about the errors and solution below:

https://github.com/mui/material-ui/issues/35287

---

Please make sure that all the checks pass. Please add here any additional information regarding this pull request. It's highly recommended that you link this PR to an issue (please create one if it doesn't exist for this PR)
