### PR TITLE
Add table fields name in sql string in View Query editor

### DIFF
--- a/src/components/Editors/View/Layout.tsx
+++ b/src/components/Editors/View/Layout.tsx
@@ -7,6 +7,7 @@ import { useTheme } from '@mui/material/styles'
 
 export default function Layout() {
   const theme = useTheme()
+
   return (
     <Box sx={{ height: theme.spacing(42) }}>
       <Columns spacing={2}>

--- a/src/components/Editors/View/Query.tsx
+++ b/src/components/Editors/View/Query.tsx
@@ -21,16 +21,17 @@ export default function Query() {
   const aceEditor = React.useRef<AceEditor>(null)
   const theme = useTheme()
 
-  const listener = (evt:any) => { 
+  const listener = (evt: any) => {
     if (aceEditor.current) {
-      if (evt.detail.field !== undefined)
+      if (evt.detail.field !== undefined) {
         aceEditor.current.editor.insert(`\`${evt.detail.field}\``)
+      }
       // We need to focus the editor again
       aceEditor.current.editor.focus()
       evt.stopImmediatePropagation()
     }
   }
-  document.addEventListener('fieldClick', listener);
+  document.addEventListener('fieldClick', listener)
 
   return (
     <Box>

--- a/src/components/Editors/View/Query.tsx
+++ b/src/components/Editors/View/Query.tsx
@@ -21,6 +21,17 @@ export default function Query() {
   const aceEditor = React.useRef<AceEditor>(null)
   const theme = useTheme()
 
+  const listener = (evt:any) => { 
+    if (aceEditor.current) {
+      if (evt.detail.field !== undefined)
+        aceEditor.current.editor.insert(`\`${evt.detail.field}\``)
+      // We need to focus the editor again
+      aceEditor.current.editor.focus()
+      evt.stopImmediatePropagation()
+    }
+  }
+  document.addEventListener('fieldClick', listener);
+
   return (
     <Box>
       {viewError ? (

--- a/src/components/Parts/Trees/FieldsTree.tsx
+++ b/src/components/Parts/Trees/FieldsTree.tsx
@@ -21,6 +21,10 @@ export default function FieldsTree(props: FileTreeProps) {
         defaultExpanded={props.expanded}
         onNodeFocus={(event: React.SyntheticEvent, nodeId: string) => {
           if (props.onPathChange) props.onPathChange(nodeId)
+          // We dispatch a fieldClick event just because in that way a component can
+          // get the focus again
+          const e = new CustomEvent('fieldClick', { detail: { 'field': undefined } })
+          document.dispatchEvent(e)
           event.stopPropagation()
         }}
         sx={{ height: '100%' }}
@@ -45,8 +49,18 @@ function TreeLabel(props: { label: React.ReactNode; type: string; path: string }
     }
   }
 
+  const event = new CustomEvent('fieldClick', { detail: { 'field': props.label } })
+  const dispatchClickEvent = (evt:any) => {
+    evt.preventDefault()
+    if (props.type !== "table") {
+      document.dispatchEvent(event)
+    } else {
+      return
+    }
+  } 
+
   return (
-    <Box sx={{ py: 1, display: 'flex', alignItems: 'center', '& svg': { mr: 1 } }}>
+    <Box onMouseDown={dispatchClickEvent} sx={{ py: 1, display: 'flex', alignItems: 'center', '& svg': { mr: 1 } }}>
       {props.label}{' '}
       <Box sx={{ color: '#4d4d4d', paddingLeft: '10px' }}>
         {formatType(props.type, props.path)}

--- a/src/components/Parts/Trees/FieldsTree.tsx
+++ b/src/components/Parts/Trees/FieldsTree.tsx
@@ -23,7 +23,7 @@ export default function FieldsTree(props: FileTreeProps) {
           if (props.onPathChange) props.onPathChange(nodeId)
           // We dispatch a fieldClick event just because in that way a component can
           // get the focus again
-          const e = new CustomEvent('fieldClick', { detail: { 'field': undefined } })
+          const e = new CustomEvent('fieldClick', { detail: { field: undefined } })
           document.dispatchEvent(e)
           event.stopPropagation()
         }}
@@ -49,18 +49,19 @@ function TreeLabel(props: { label: React.ReactNode; type: string; path: string }
     }
   }
 
-  const event = new CustomEvent('fieldClick', { detail: { 'field': props.label } })
-  const dispatchClickEvent = (evt:any) => {
+  const event = new CustomEvent('fieldClick', { detail: { field: props.label } })
+  const dispatchClickEvent = (evt: any) => {
     evt.preventDefault()
-    if (props.type !== "table") {
+    if (props.type !== 'table') {
       document.dispatchEvent(event)
-    } else {
-      return
     }
-  } 
+  }
 
   return (
-    <Box onMouseDown={dispatchClickEvent} sx={{ py: 1, display: 'flex', alignItems: 'center', '& svg': { mr: 1 } }}>
+    <Box
+      onMouseDown={dispatchClickEvent}
+      sx={{ py: 1, display: 'flex', alignItems: 'center', '& svg': { mr: 1 } }}
+    >
       {props.label}{' '}
       <Box sx={{ color: '#4d4d4d', paddingLeft: '10px' }}>
         {formatType(props.type, props.path)}


### PR DESCRIPTION
Implement  "inserting a field name to Query on a double click on a field name in Fields" from #114.

The solution in this PR is a bit problematic, but I couldn't find a better way to prevent the ACE editor to lose focus when the user clicks anywhere in the FieldsTree. The problem with that is  not just that  we lose the focus, but also there is an event on the ace editor to validate the query when the editor is out of focus, but this doesn't make sense in that case.